### PR TITLE
bucket name is taken from the name variable

### DIFF
--- a/aws/s3-bucket/main.tf
+++ b/aws/s3-bucket/main.tf
@@ -11,7 +11,7 @@ terraform {
 data "aws_region" "current" {}
 
 resource "aws_s3_bucket" "this" {
-  bucket = "${var.name}-${data.aws_region.current.name}-${var.suffix}"
+  bucket = var.name
 
   tags = var.tags
 }


### PR DESCRIPTION
This way we can choose the full name of the bucket instead of the module injecting unwanted stuff to the bucket name